### PR TITLE
Rename exported Run to Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/nakabonne/fmtdiff)
 [![codecov](https://codecov.io/gh/nakabonne/fmtdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/nakabonne/fmtdiff)
 
-A `goimports` client as well as a parser that parses the diff between an original file and one formatted by it.  
+A `goimports` client as well as a parser that parses the diff between an original file and formatted one. You can use it as a wrapper for [golang.org/x/tools/imports](https://godoc.org/golang.org/x/tools/imports).  
 
 goimports not only fixes imports, but also formats your code in the same style as gofmt, so `fmtdiff` means `importsdiff` substantially.
 
@@ -21,8 +21,8 @@ package main
 import "github.com/nakabonne/fmtdiff"
 
 func main() {	
-	fileDiff, _ := fmtdiff.Run("/path/to/foo.go", &fmtdiff.Options{
-		LocalPrefixes:  []string{"github.com/myOrg/myRepo"},
+	fileDiff, _ := fmtdiff.Process("/path/to/foo.go", &fmtdiff.Options{
+		LocalPrefixes:  []string{"example.com/foo/bar"},
                 IgnoreComments: true,
                 FormatOnly:     true,
 	})	

--- a/fmtdiff.go
+++ b/fmtdiff.go
@@ -1,3 +1,6 @@
+// Package fmtdiff implements a goimports client as well as a parser that
+// parses the diff between an original file and formatted one.
+// You can use it as a wrapper for golang.org/x/tools/imports.
 package fmtdiff
 
 import (
@@ -64,8 +67,12 @@ type Options struct {
 
 var defaultTabWidth = 8
 
-// Run runs goimports and parses the diff between an original file and a formatted one.
-func Run(filename string, options *Options) (*FileDiff, error) {
+// Process runs goimports and parses the diff between an original file and a formatted one.
+//
+// Note that filename's directory influences which imports can be chosen,
+// so it is important that filename be accurate.
+// To process data “as if” it were in filename, pass the data as a non-nil src.
+func Process(filename string, options *Options) (*FileDiff, error) {
 	fileDiff := &FileDiff{Name: filename}
 	if options == nil {
 		options = &Options{}

--- a/fmtdiff_test.go
+++ b/fmtdiff_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun(t *testing.T) {
+func TestProcess(t *testing.T) {
 	localPrefix := "github.com/nakabonne/fmtdiff"
 	cases := []struct {
 		name     string
@@ -33,7 +33,7 @@ import (
 )
 
 func _() {
-	_, _ = fmtdiff.Run("", nil)
+	_, _ = fmtdiff.Process("", nil)
 	fmt.Println("fmt")
 	_, _ = unusedparam.Check("")
 }
@@ -49,7 +49,7 @@ import (
 )
 
 func _() {
-	_, _ = fmtdiff.Run("", nil)
+	_, _ = fmtdiff.Process("", nil)
 	fmt.Println("fmt")
 	_, _ = unusedparam.Check("")
 }
@@ -94,7 +94,7 @@ import (
 )
 
 func _() {
-	_, _ = fmtdiff.Run("", nil)
+	_, _ = fmtdiff.Process("", nil)
 	fmt.Println("fmt")
 	_, _ = unusedparam.Check("")
 }
@@ -109,7 +109,7 @@ import (
 )
 
 func _() {
-	_, _ = fmtdiff.Run("", nil)
+	_, _ = fmtdiff.Process("", nil)
 	fmt.Println("fmt")
 	_, _ = unusedparam.Check("")
 }
@@ -122,7 +122,7 @@ func _() {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			f, err := Run(tc.filename, tc.options)
+			f, err := Process(tc.filename, tc.options)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.expected, f)
 		})

--- a/testdata/local_prefix.go
+++ b/testdata/local_prefix.go
@@ -8,7 +8,7 @@ import (
 )
 
 func _() {
-	_, _ = fmtdiff.Run("", nil)
+	_, _ = fmtdiff.Process("", nil)
 	fmt.Println("fmt")
 	_, _ = unusedparam.Check("")
 }


### PR DESCRIPTION
Renamed, to be clear that fmtdiff is a wrapper for tools/imports.